### PR TITLE
Review docs for management port

### DIFF
--- a/docs/documentation/release_notes/topics/25_0_0.adoc
+++ b/docs/documentation/release_notes/topics/25_0_0.adoc
@@ -44,4 +44,4 @@ It allows to not expose it to the users as standard Keycloak endpoints in Kubern
 The new management interface provides a new set of options and is fully configurable.
 
 {project_name} Operator assumes the management interface is turned on by default.
-For more details, see https://www.keycloak.org/server/management-interface[Configuring {project_name} Management Interface].
+For more details, see https://www.keycloak.org/server/management-interface[Configuring the Management Interface].

--- a/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
@@ -90,4 +90,4 @@ However, this property is deprecated and will be removed in future releases, so 
 The management interface uses a different HTTP server than the default {project_name} HTTP server, and it is possible to configure them separately.
 Beware, if no values are supplied for the management interface properties, they are inherited from the default {project_name} HTTP server.
 
-For more details, see https://www.keycloak.org/server/management-interface[Configuring {project_name} Management Interface].
+For more details, see https://www.keycloak.org/server/management-interface[Configuring the Management Interface].

--- a/docs/guides/operator/advanced-configuration.adoc
+++ b/docs/guides/operator/advanced-configuration.adoc
@@ -205,6 +205,27 @@ It is achieved by providing certain JVM options.
 
 For more details, see <@links.server id="containers" />.
 
+== Management Interface
+
+To change the port of the management interface, use the first-class citizen field `httpManagement.port` in the Keycloak CR.
+To change the properties of the management interface, you can do it by providing `additionalOptions` field.
+
+You can specify the `port` and the `additionalOptions` as follows:
+
+[source,yaml]
+----
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: example-kc
+spec:
+  httpManagement:
+    port: 9001
+  additionalOptions:
+    - name: http-management-relative-path
+      value: /management
+----
+
 === Truststores
 
 If you need to provide trusted certificates, the Keycloak CR provides a top level feature for configuring the server's truststore as discussed in <@links.server id="keycloak-truststore"/>.

--- a/docs/guides/server/configuration-metrics.adoc
+++ b/docs/guides/server/configuration-metrics.adoc
@@ -18,7 +18,7 @@ It is possible to enable metrics using the build time option `metrics-enabled`:
 
 == Querying Metrics
 
-{project_name} exposes metrics at the following endpoint on management port `9000`:
+{project_name} exposes metrics at the following endpoint on management port:
 
 * `/metrics`
 

--- a/docs/guides/server/management-interface.adoc
+++ b/docs/guides/server/management-interface.adoc
@@ -3,8 +3,8 @@
 <#import "/templates/links.adoc" as links>
 
 <@tmpl.guide
-title="Configuring {project_name} Management Interface"
-summary="Learn how to configure {project_name}'s management interface for endpoints like Metrics and Health checks."
+title="Configuring the Management Interface"
+summary="Learn how to configure {project_name}'s management interface for endpoints like metrics and health checks."
 includedOptions="http-management-* https-management-* legacy-observability-interface">
 
 The management interface allows accessing management endpoints via a different HTTP server than the primary one.
@@ -13,10 +13,10 @@ The most significant advantage might be seen in Kubernetes environments as the s
 
 == Management interface configuration
 
-The management interface is turned on by default, so management endpoints such as `/metrics`, and `/health` are exposed on port `9000`.
+The management interface is turned on by default, so management endpoints such as `/metrics`, and `/health` are exposed on the default management port `9000`.
 In order to change the port for the management interface, you can use the {project_name} option `http-management-port` or environment variable `KC_HTTP_MANAGEMENT_PORT`.
 
-The new management interface provides a new set of options and is fully configurable.
+The management interface provides a set of options and is fully configurable.
 If these options for the management HTTP server are not explicitly set, their values are automatically inherited from the default HTTP server.
 
 You can change the relative path of the management interface, as the prefix path for the management endpoints can be different.
@@ -24,42 +24,27 @@ You can achieve it via the {project_name} option `http-management-relative-path`
 
 For instance, if you set the CLI option `--http-management-relative-path=/management`, the metrics, and health endpoints will be accessed on the `/management/metrics` and `/management/health` paths.
 
-Beware, if you do not explicitly set the value for it, the value from the `http-relative-path` property is used.
-
-== {project_name} Operator
-{project_name} Operator provides only one first-class citizen field `port` in the Keycloak CR.
-However, if it is necessary to change the properties of the management interface, you can do it by providing `additionalOptions` field.
-
-You can specify the `port` and the `additionalOptions` as follows:
-[source,yaml]
-----
-apiVersion: k8s.keycloak.org/v2alpha1
-kind: Keycloak
-metadata:
-  name: example-kc
-spec:
-  httpManagement:
-    port: 9001
-  additionalOptions:
-    - name: http-management-relative-path
-      value: /management
-----
+NOTE: If you do not explicitly set the value for it, the value from the `http-relative-path` property is used.
 
 == TLS support
-When the TLS is set for the default {project_name} server, the management interface will be accessible through the HTTPS as well.
+
+When the TLS is set for the default {project_name} server, the management interface will be accessible through HTTPS as well.
 The management interface can run only either on HTTP or HTTPS, not both as for the main server.
 
 Specific {project_name} management interface options with the prefix `https-management-*` were provided for setting different TLS parameters for the management HTTP server.
 When these options are not explicitly set, the TLS parameters are inherited from the default HTTP server.
 
 == Disable Management interface
+
 The management interface is automatically turned off when nothing is exposed on it.
-Currently, only health checks and metrics are exposed on the management interface regardless their state.
+Currently, only health checks and metrics are exposed on the management interface regardless.
 If you want to disable exposing them on the management interface, set the {project_name} property `legacy-observability-interface` to `true`.
 
 [WARNING]
-Exposing health and metrics endpoints on the default server is not recommended, and you should always use the management interface.
+====
+Exposing health and metrics endpoints on the default server is not recommended for security reasons, and you should always use the management interface.
 Beware, the `legacy-observability-interface` option is deprecated and will be removed in future releases.
 It only allows you to give more time for the migration.
+====
 
 </@tmpl.guide>


### PR DESCRIPTION
The major theme in this change: 

* Don't put "Keycloak" in headings, as everything is about Keycloak, and downstream it is even longer with "Red Hat build of Keycloak"
* Keep the parts relevant to the Operator in the advanced operator details like we did for the truststore parts. 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
