### PR TITLE
test: cover group permission evaluation

### DIFF
--- a/js/apps/admin-ui/test/permissions/main.spec.ts
+++ b/js/apps/admin-ui/test/permissions/main.spec.ts
@@ -172,6 +172,14 @@ test.describe.serial("Permissions section tests", () => {
         page.getByRole("heading", { name: "Warning alert: account with" }),
       ).toBeVisible();
     });
+
+    test("should select groups for evaluation", async ({ page }) => {
+      await goToEvaluation(page);
+      await selectItem(page, page.getByTestId("user"), "user1");
+      await selectItem(page, "#resourceType", "Groups");
+
+      await expect(page.getByTestId("select-group-button")).toBeVisible();
+    });
   });
 
   test.describe.serial("permission search", () => {


### PR DESCRIPTION
Follow-up to #51538.

This adds the focused Playwright regression case requested in review. It opens the Permissions Evaluation tab, selects `user1`, switches the resource type to `Groups`, and verifies that the group selector renders. The case covers the path where the optional group field is mounted before it has a value.

Validation:
- `pnpm dlx prettier@3.6.2 --check apps/admin-ui/test/permissions/main.spec.ts` (passed)
- The full Playwright suite was not run locally because the workspace dependencies are not installed in this checkout.

AI assistance disclosure: I used AI assistance while preparing this change, then reviewed the diff and test flow against the existing Keycloak Playwright helpers and maintainer feedback.

DCO sign-off is included in the commit.